### PR TITLE
Start position at 1 like filament reorderable

### DIFF
--- a/src/Forms/Components/Concerns/HasRelationship.php
+++ b/src/Forms/Components/Concerns/HasRelationship.php
@@ -61,7 +61,7 @@ trait HasRelationship
 
                     /* Update item order */
                     if ($orderColumn) {
-                        $record->{$orderColumn} = $pivotAttributes[$orderColumn] = array_search($itemKey, array_keys($siblings ?: $state));
+                        $record->{$orderColumn} = $pivotAttributes[$orderColumn] = array_search($itemKey, array_keys($siblings ?: $state)) + 1;
                     }
 
                     if ($relationship instanceof BelongsToMany) {


### PR DESCRIPTION
Filament reorderable start position at 1 and it should be like Filament.

You can take a look here in Filament : 
filament\tables\src\Concerns\CanReorderRecords.php

```php
foreach ($order as $index => $recordKey) {
    $this->getTableRecord($recordKey)->{$relationship->getPivotAccessor()}->update([
        $orderColumn => $index + 1,
    ]);
}
```