### PR TITLE
4.x auth actions

### DIFF
--- a/src/Forms/Components/Actions/AddAction.php
+++ b/src/Forms/Components/Actions/AddAction.php
@@ -75,7 +75,7 @@ class AddAction extends Action
 
         $this->authorize(function (Component $component): bool {
             try {
-                return \Filament\authorize('create', $component->getModel())->allowed();
+                return ! $component->getRelatedModel() || \Filament\authorize('create', $component->getModel())->allowed();
             } catch (AuthorizationException $exception) {
                 return $exception->toResponse()->allowed();
             }

--- a/src/Forms/Components/Actions/AddAction.php
+++ b/src/Forms/Components/Actions/AddAction.php
@@ -4,6 +4,7 @@ namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Forms\Form;
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Str;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
@@ -71,5 +72,13 @@ class AddAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isAddable()
         );
+
+        $this->authorize(function (Component $component): bool {
+            try {
+                return \Filament\authorize('create', $component->getModel())->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/AddChildAction.php
+++ b/src/Forms/Components/Actions/AddChildAction.php
@@ -80,7 +80,7 @@ class AddChildAction extends Action
 
         $this->authorize(function (Component $component): bool {
             try {
-                return \Filament\authorize('create', $component->getModel())->allowed();
+                return ! $component->getRelatedModel() || \Filament\authorize('create', $component->getModel())->allowed();
             } catch (AuthorizationException $exception) {
                 return $exception->toResponse()->allowed();
             }

--- a/src/Forms/Components/Actions/AddChildAction.php
+++ b/src/Forms/Components/Actions/AddChildAction.php
@@ -4,6 +4,7 @@ namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Forms\Form;
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Str;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
@@ -76,5 +77,13 @@ class AddChildAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isAddable()
         );
+
+        $this->authorize(function (Component $component): bool {
+            try {
+                return \Filament\authorize('create', $component->getModel())->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/DedentAction.php
+++ b/src/Forms/Components/Actions/DedentAction.php
@@ -60,7 +60,7 @@ class DedentAction extends Action
             try {
                 $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
 
-                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+                return ! $record || \Filament\authorize('update', $record)->allowed();
             } catch (AuthorizationException $exception) {
                 return $exception->toResponse()->allowed();
             }

--- a/src/Forms/Components/Actions/DedentAction.php
+++ b/src/Forms/Components/Actions/DedentAction.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
@@ -54,5 +55,15 @@ class DedentAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isIndentable()
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/DeleteAction.php
+++ b/src/Forms/Components/Actions/DeleteAction.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
 class DeleteAction extends Action
@@ -44,5 +45,15 @@ class DeleteAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isDeletable()
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('delete', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/EditAction.php
+++ b/src/Forms/Components/Actions/EditAction.php
@@ -4,6 +4,7 @@ namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Forms\Form;
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
 class EditAction extends Action
@@ -67,5 +68,15 @@ class EditAction extends Action
                 return $component->isEditable();
             }
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('update', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/IndentAction.php
+++ b/src/Forms/Components/Actions/IndentAction.php
@@ -70,7 +70,7 @@ class IndentAction extends Action
             try {
                 $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
 
-                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+                return ! $record || \Filament\authorize('update', $record)->allowed();
             } catch (AuthorizationException $exception) {
                 return $exception->toResponse()->allowed();
             }

--- a/src/Forms/Components/Actions/IndentAction.php
+++ b/src/Forms/Components/Actions/IndentAction.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
@@ -64,5 +65,15 @@ class IndentAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isIndentable()
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/MoveDownAction.php
+++ b/src/Forms/Components/Actions/MoveDownAction.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Str;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
@@ -61,5 +62,15 @@ class MoveDownAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isMoveable()
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/MoveUpAction.php
+++ b/src/Forms/Components/Actions/MoveUpAction.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Str;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
@@ -61,5 +62,15 @@ class MoveUpAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isMoveable()
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }

--- a/src/Forms/Components/Actions/ReorderAction.php
+++ b/src/Forms/Components/Actions/ReorderAction.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentAdjacencyList\Forms\Components\Actions;
 
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Auth\Access\AuthorizationException;
 use Saade\FilamentAdjacencyList\Forms\Components\Component;
 
 class ReorderAction extends Action
@@ -27,5 +28,15 @@ class ReorderAction extends Action
         $this->visible(
             fn (Component $component): bool => $component->isReorderable()
         );
+
+        $this->authorize(function (Component $component, array $arguments): bool {
+            try {
+                $record = $component->getRelatedModel() ? $component->getCachedExistingRecords()->get($arguments['cachedRecordKey']) : null;
+
+                return ! $record || \Filament\authorize('reorder', $record)->allowed();
+            } catch (AuthorizationException $exception) {
+                return $exception->toResponse()->allowed();
+            }
+        });
     }
 }


### PR DESCRIPTION
As per our discussion in DM, adding policy checks to actions.

By default, if no getRelatedModel() all authorize() will return true.  If there is a related model, call Filament's authorize() helper with the relevant action name, and either the specific model record, or the model class name (for add / addChild).