### PR TITLE
performance: Cache related model

### DIFF
--- a/src/Forms/Components/Concerns/HasRelationship.php
+++ b/src/Forms/Components/Concerns/HasRelationship.php
@@ -20,6 +20,8 @@ trait HasRelationship
 
     protected ?Collection $cachedExistingRecords = null;
 
+    protected ?string $cachedRelatedModel = null;
+
     protected string | Closure | null $orderColumn = null;
 
     protected ?Closure $modifyRelationshipQueryUsing = null;
@@ -357,7 +359,7 @@ trait HasRelationship
 
     public function getRelatedModel(): ?string
     {
-        return ($model = $this->getRelationship()?->getModel()) ? $model::class : null;
+        return $this->cachedRelatedModel ??= ($model = $this->getRelationship()?->getModel()) ? $model::class : null;
     }
 
     public function mutateRelationshipDataBeforeCreateUsing(?Closure $callback): static


### PR DESCRIPTION
When instantiating the adjacency relationship to fetch the related model, a DB query is made by the underlying adjacency package to check the DB structure. Fetching the related model happens very often (at least once for each item in the list for policy checks) and this slows the page down significantly. In my test case, the list now loads in ~400ms instead of ~3s.